### PR TITLE
Added: HOST URL for Lexware Office Sandbox Account

### DIFF
--- a/src/main/java/de/focus_shift/lexoffice/java/sdk/LexofficeApiBuilder.java
+++ b/src/main/java/de/focus_shift/lexoffice/java/sdk/LexofficeApiBuilder.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 public class LexofficeApiBuilder {
 
     public static final String LEXOFFICE_API = "api.lexware.io/v1";
-    public static final String LEXOFFICE_SANDBOX_API = "api.lexware-sandbox.io/v1";
 
     private String host = LEXOFFICE_API;
     private String apiToken = null;
@@ -19,8 +18,8 @@ public class LexofficeApiBuilder {
     }
 
 
-    public LexofficeApiBuilder sandboxed(boolean sandboxed) {
-        this.host = sandboxed ? LEXOFFICE_SANDBOX_API : LEXOFFICE_API;
+    public LexofficeApiBuilder host(String host) {
+        this.host = host;
         return this;
     }
 

--- a/src/main/java/de/focus_shift/lexoffice/java/sdk/LexofficeApiBuilder.java
+++ b/src/main/java/de/focus_shift/lexoffice/java/sdk/LexofficeApiBuilder.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 public class LexofficeApiBuilder {
 
     public static final String LEXOFFICE_API = "api.lexware.io/v1";
+    public static final String LEXOFFICE_SANDBOX_API = "api.lexware-sandbox.io/v1";
 
     private String host = LEXOFFICE_API;
     private String apiToken = null;
@@ -17,6 +18,11 @@ public class LexofficeApiBuilder {
         return this;
     }
 
+
+    public LexofficeApiBuilder sandboxed(boolean sandboxed) {
+        this.host = sandboxed ? LEXOFFICE_SANDBOX_API : LEXOFFICE_API;
+        return this;
+    }
 
     public LexofficeApiBuilder throttleProvider(ThrottleProvider throttleProvider) {
         this.throttleProvider = throttleProvider;


### PR DESCRIPTION
This pull request introduces support for a sandbox environment in the `LexofficeApiBuilder` class, allowing developers to toggle between the production and sandbox APIs. The changes include the addition of a new constant and a method to configure the sandbox mode.

### Sandbox environment support:

Added a new constant `LEXOFFICE_SANDBOX_API` to define the sandbox API endpoint.
Introduced a new method `sandboxed(boolean sandboxed)` to allow switching between the production and sandbox API endpoints by updating the `host` field accordingly.


Edit: Label was not possible, maybe I don't have permission - Or I just din't get it, as I'm new to GitHub
